### PR TITLE
Fixed wrong relocation size variable name

### DIFF
--- a/RedBackdoorer.py
+++ b/RedBackdoorer.py
@@ -823,7 +823,7 @@ Sources:
             reloc_type = imageBaseRelocType << 12
 
             relocWord = (reloc_type | reloc_offset)
-            self.pe.set_word_at_rva(relocDirRva + relocsSize + 8 + i * 2, relocWord)
+            self.pe.set_word_at_rva(relocDirRva + sizeOfReloc + 8 + i * 2, relocWord)
             self.logger.dbg(f'\tReloc{i} for addr 0x{reloc:x}: 0x{relocWord:x} - 0x{reloc_offset:x} - type: {imageBaseRelocType}')
             i += 1
 


### PR DESCRIPTION
Redbackdoorer.py seemed to have a typo in the relocation size variable name. When running the tool with the option to append shellcode to the PE file in a new PE section (x,2), the run would fail as the variable _relocsSize_ was not found. Just couple of lines above in the code the relocation size variable is defined and used with the name _sizeOfReloc_.

Run error:
![image](https://user-images.githubusercontent.com/6648537/227197118-0e965991-d175-411b-ab7d-732ea50d47cf.png)
